### PR TITLE
fix(budget): Use budget type over budget id

### DIFF
--- a/src/main/java/com/factotum/oaka/converter/BudgetSummaryConverter.java
+++ b/src/main/java/com/factotum/oaka/converter/BudgetSummaryConverter.java
@@ -12,7 +12,6 @@ public class BudgetSummaryConverter implements Converter<Row, TransactionBudgetS
     @Override
     public TransactionBudgetSummary convert(Row source) {
         return new TransactionBudgetSummary(
-                source.get("transaction_type", String.class),
                 source.get("month", Integer.class),
                 source.get("year", Integer.class),
                 source.get("sum", BigDecimal.class)

--- a/src/main/java/com/factotum/oaka/dto/TransactionBudgetSummary.java
+++ b/src/main/java/com/factotum/oaka/dto/TransactionBudgetSummary.java
@@ -16,9 +16,6 @@ import java.math.BigDecimal;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionBudgetSummary {
 
-    @JsonProperty("transactionType")
-    private String transactionType;
-
     @JsonProperty("category")
     private String category;
 
@@ -41,11 +38,9 @@ public class TransactionBudgetSummary {
     private boolean expected;
 
     public TransactionBudgetSummary(
-            String transactionType,
             Integer month,
             Integer year,
             BigDecimal actual) {
-        this.transactionType = transactionType;
         this.month = month;
         this.year = year;
         this.actual = actual;

--- a/src/main/java/com/factotum/oaka/dto/TransactionTypeTotal.java
+++ b/src/main/java/com/factotum/oaka/dto/TransactionTypeTotal.java
@@ -1,5 +1,6 @@
 package com.factotum.oaka.dto;
 
+import com.factotum.oaka.enumeration.BudgetType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -16,8 +17,8 @@ import java.math.BigDecimal;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionTypeTotal {
 
-    @JsonProperty("transactionType")
-    private String transactionType;
+    @JsonProperty("budgetType")
+    private BudgetType budgetType;
 
     @JsonProperty("total")
     private BigDecimal total;

--- a/src/main/java/com/factotum/oaka/enumeration/BudgetType.java
+++ b/src/main/java/com/factotum/oaka/enumeration/BudgetType.java
@@ -1,0 +1,5 @@
+package com.factotum.oaka.enumeration;
+
+public enum BudgetType {
+    INCOME, EXPENSE
+}

--- a/src/main/java/com/factotum/oaka/repository/TransactionRepository.java
+++ b/src/main/java/com/factotum/oaka/repository/TransactionRepository.java
@@ -22,16 +22,26 @@ public interface TransactionRepository extends ReactiveCrudRepository<Transactio
             "ORDER BY transaction_date DESC")
     Flux<TransactionDto> findAllByOrderByDateDesc(@Param("tenantId") String tenantId);
 
-    @Query("SELECT tt.transaction_type, month(t.transaction_date) as month, year(t.transaction_date) as year, ABS(SUM(t.amount)) as sum " +
+    @Query("SELECT month(t.transaction_date) as month, year(t.transaction_date) as year, ABS(SUM(t.amount)) as sum " +
             "FROM transaction t " +
-            "INNER JOIN transaction_type tt on tt.transaction_type_id = t.transaction_type_id " +
             "WHERE month(t.transaction_date) = :month " +
             "  AND year(transaction_date) = :year " +
             "  AND t.budget_id in (:budgetIds) " +
-            "  AND tt.transaction_type_id = :typeId " +
+            "  AND t.amount >= 0 " +
             "  AND t.tenant_id = :tenantId " +
-            "GROUP BY month(t.transaction_date), year(t.transaction_date), tt.transaction_type " +
-            "ORDER BY month(t.transaction_date), year(t.transaction_date), tt.transaction_type DESC;")
-    Mono<TransactionBudgetSummary> getBudgetSummaries(int month, int year, Set<Long> budgetIds, int typeId, String tenantId);
+            "GROUP BY month(t.transaction_date), year(t.transaction_date) " +
+            "ORDER BY month(t.transaction_date), year(t.transaction_date) DESC;")
+    Mono<TransactionBudgetSummary> getIncomeTransactionSummary(int month, int year, Set<Long> budgetIds, String tenantId);
+
+    @Query("SELECT month(t.transaction_date) as month, year(t.transaction_date) as year, ABS(SUM(t.amount)) as sum " +
+            "FROM transaction t " +
+            "WHERE month(t.transaction_date) = :month " +
+            "  AND year(transaction_date) = :year " +
+            "  AND t.budget_id in (:budgetIds) " +
+            "  AND t.amount < 0 " +
+            "  AND t.tenant_id = :tenantId " +
+            "GROUP BY month(t.transaction_date), year(t.transaction_date) " +
+            "ORDER BY month(t.transaction_date), year(t.transaction_date) DESC;")
+    Mono<TransactionBudgetSummary> getExpenseTransactionSummary(int month, int year, Set<Long> budgetIds, String tenantId);
 
 }

--- a/src/main/resources/db/migration/V3_0__drop_transaction_type.sql
+++ b/src/main/resources/db/migration/V3_0__drop_transaction_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transaction DROP COLUMN transaction_type_id;

--- a/src/test/java/com/factotum/oaka/controller/TransactionControllerIT.java
+++ b/src/test/java/com/factotum/oaka/controller/TransactionControllerIT.java
@@ -5,6 +5,7 @@ import com.factotum.oaka.dto.BudgetCategoryDto;
 import com.factotum.oaka.dto.BudgetDto;
 import com.factotum.oaka.dto.ShortAccountDto;
 import com.factotum.oaka.dto.TransactionDto;
+import com.factotum.oaka.enumeration.BudgetType;
 import com.factotum.oaka.http.AccountService;
 import com.factotum.oaka.http.BudgetService;
 import com.factotum.oaka.util.SecurityTestUtil;
@@ -262,7 +263,7 @@ class TransactionControllerIT {
                         uriBuilder.path(URI + "/total")
                                 .queryParam("year", "2017")
                                 .queryParam("month", "1")
-                                .queryParam("transactionTypeId", "2")
+                                .queryParam("budgetType", BudgetType.EXPENSE)
                                 .queryParam("budgetIds", "10, 11, 12, 13, 14, 15, 26, 16, 17, 18, 27, 19, 28, 29, 30")
                                 .build())
                 .exchange()
@@ -270,7 +271,7 @@ class TransactionControllerIT {
                 .expectBody()
                 .consumeWith(System.out::println)
                 .jsonPath("$.total").exists()
-                .jsonPath("$.transactionType").exists();
+                .jsonPath("$.budgetType").exists();
 
     }
 
@@ -285,14 +286,14 @@ class TransactionControllerIT {
                         uriBuilder.path(URI + "/total")
                                 .queryParam("year", "2017")
                                 .queryParam("month", "1")
-                                .queryParam("transactionTypeId", "1")
+                                .queryParam("budgetType", BudgetType.INCOME)
                                 .queryParam("budgetIds", "20")
                                 .build())
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$.total").exists()
-                .jsonPath("$.transactionType").exists();
+                .jsonPath("$.budgetType").exists();
 
     }
 
@@ -307,14 +308,14 @@ class TransactionControllerIT {
                         uriBuilder.path(URI + "/total")
                                 .queryParam("year", "2017")
                                 .queryParam("month", "1")
-                                .queryParam("transactionTypeId", "2")
+                                .queryParam("budgetType", BudgetType.EXPENSE)
                                 .queryParam("budgetIds", "1, 2, 3, 4, 5, 6, 21, 22")
                                 .build())
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$.total").exists()
-                .jsonPath("$.transactionType").exists();
+                .jsonPath("$.budgetType").exists();
 
     }
 
@@ -329,14 +330,14 @@ class TransactionControllerIT {
                         uriBuilder.path(URI + "/total")
                                 .queryParam("year", "2017")
                                 .queryParam("month", "1")
-                                .queryParam("transactionTypeId", "1")
+                                .queryParam("budgetType", BudgetType.INCOME)
                                 .queryParam("budgetIds", "23")
                                 .build())
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$.total").exists()
-                .jsonPath("$.transactionType").exists();
+                .jsonPath("$.budgetType").exists();
 
     }
 
@@ -350,13 +351,13 @@ class TransactionControllerIT {
                 .uri(uriBuilder -> uriBuilder.path(URI + "/total")
                         .queryParam("year", "2017")
                         .queryParam("month", "1")
-                        .queryParam("transactionTypeId", "2")
+                        .queryParam("budgetType", BudgetType.EXPENSE)
                         .queryParam("budgetIds", "24, 7, 8, 9, 25").build())
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
                 .jsonPath("$.total").exists()
-                .jsonPath("$.transactionType").exists();
+                .jsonPath("$.budgetType").exists();
 
     }
 

--- a/src/test/java/com/factotum/oaka/repository/TransactionRepositoryIT.java
+++ b/src/test/java/com/factotum/oaka/repository/TransactionRepositoryIT.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -29,13 +30,12 @@ class TransactionRepositoryIT {
     private TransactionRepository transactionRepository;
 
     @Test
-    void getBudgetSummaries() {
+    void getExpenseTransactionSummary_GivenExpenseTransactionsExistInRange_ThenReturnValue() {
         TransactionBudgetSummary summary = transactionRepository
-                .getBudgetSummaries(
+                .getExpenseTransactionSummary(
                         1,
                         2017,
                         new HashSet<>(Arrays.asList(10L, 11L, 12L, 13L, 14L, 15L, 26L, 16L, 17L, 18L, 27L, 19L, 28L, 29L, 30L)),
-                        2,
                         "684996db-6cf8-4976-8336-6e664386dcda"
                 )
                 .block();
@@ -44,7 +44,24 @@ class TransactionRepositoryIT {
         assertThat(summary.getActual(), is(equalTo(BigDecimal.valueOf(380.51))));
         assertThat(summary.getMonth(), is(equalTo(1)));
         assertThat(summary.getYear(), is(equalTo(2017)));
-        assertThat(summary.getTransactionType(), is(equalTo("Expense")));
+
+    }
+
+    @Test
+    void getIncomeTransactionSummary_GivenIncomeTransactionsExistInRange_ThenReturnValue() {
+        TransactionBudgetSummary summary = transactionRepository
+                .getIncomeTransactionSummary(
+                        1,
+                        2017,
+                        new HashSet<>(List.of(20L)),
+                        "684996db-6cf8-4976-8336-6e664386dcda"
+                )
+                .block();
+        assertThat(summary, is(not(nullValue())));
+
+        assertThat(summary.getActual(), is(equalTo(BigDecimal.valueOf(2000))));
+        assertThat(summary.getMonth(), is(equalTo(1)));
+        assertThat(summary.getYear(), is(equalTo(2017)));
 
     }
 


### PR DESCRIPTION
Fixes the exception thrown when getting the budget summary.

Budgets were never saving the transaction type on creation or update. This caused the query to fail. To fix this, the transaction type table was fully removed and replaced with an enum that defined it on the budget category level rather than on the budget or transaction level. Transactions are now evaluated to be expense or income based on whether their value is negative or positive.

BREAKING CHANGE