### PR TITLE
fix(kubernetes): Use fabric8 client to avoid log error"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <!--Spring Cloud starters-->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
+            <artifactId>spring-cloud-starter-kubernetes-fabric8-all</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/src/test/java/com/factotum/oaka/service/TransactionRetrievalServiceImplIT.java
+++ b/src/test/java/com/factotum/oaka/service/TransactionRetrievalServiceImplIT.java
@@ -7,21 +7,16 @@ import com.factotum.oaka.dto.ShortAccountDto;
 import com.factotum.oaka.dto.TransactionDto;
 import com.factotum.oaka.http.AccountService;
 import com.factotum.oaka.http.BudgetService;
-import com.factotum.oaka.model.Transaction;
 import com.factotum.oaka.util.SecurityTestUtil;
-import org.apache.commons.collections4.map.HashedMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.oauth2.jwt.Jwt;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 

--- a/src/test/java/com/factotum/oaka/util/SecurityTestUtil.java
+++ b/src/test/java/com/factotum/oaka/util/SecurityTestUtil.java
@@ -1,9 +1,9 @@
 package com.factotum.oaka.util;
 
-import org.apache.commons.collections4.map.HashedMap;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 
 public class SecurityTestUtil {
@@ -17,10 +17,10 @@ public class SecurityTestUtil {
 
     public static Jwt getTestJwt(String userId) {
 
-        Map<String, Object> claims = new HashedMap<>();
+        Map<String, Object> claims = new HashMap<>();
         claims.put("sub", userId);
 
-        Map<String, Object> headers = new HashedMap<>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("typ", "JWT");
         headers.put("alg", "RS256");
 


### PR DESCRIPTION
The logs consistently output ReflectorRunnable error caused by "too old resource version".

This is intended to fix it.